### PR TITLE
[fixed] replacement error &  /etc/sysctl.conf path fixed

### DIFF
--- a/ocserv-install.sh
+++ b/ocserv-install.sh
@@ -4,10 +4,18 @@ install() {
 
 apt update -y
 
-# need to fill up your domain name or IP here
-# If you want to use domain name, you gotta setup DNS A record at first.
-# For instance: vpn.yourdomain.com x.x.x.x
-ip=''
+
+echo "Please select connection method:"
+echo "1) Domain Name"
+echo "2) IP Address"
+read -p "Input number [1-2]: " host_type
+
+if [ "$host_type" == "1" ]; then
+    read -p "Enter Your Domain Name: " ip
+else
+    ip=$(hostname -I | cut -f1 -d ' ')
+    echo " Auto-detected IP: $ip"
+fi
 echo "Your Server Host Name is:$ip"
 
 echo -e "\e[32mInstalling gnutls-bin\e[39m"


### PR DESCRIPTION
After running the installation script, I found some issues.

1. The OS I used was Debain >6.12. However, there's no `/etc/sysctl.conf` file. The new version use `/etc/sysctl.d/xxx` more to set up.
2. When I checked the `/etc/ocserv/ocserv.conf`, there were some error:
   - try-mtu-discovery = truefalse
   - cisco-client-compat = true = true
 
So I updated the match rules.